### PR TITLE
Adds a Generator to GLSL

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'fdssl'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=fdssl",
+                    "--package=fdssl"
+                ],
+                "filter": {
+                    "name": "fdssl",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'fdssl'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=fdssl",
+                    "--package=fdssl"
+                ],
+                "filter": {
+                    "name": "fdssl",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,11 +3,15 @@
 version = 3
 
 [[package]]
-name = "FDSSL"
-version = "0.1.0"
+name = "bitvec"
+version = "0.19.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
 dependencies = [
- "itertools",
- "nom",
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -15,6 +19,30 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "fdssl"
+version = "0.1.0"
+dependencies = [
+ "glsl",
+ "itertools",
+ "nom 7.1.0",
+]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
+name = "glsl"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd49bbe5e12dd5aed9d66a84899af422f3d4fcfdd20b2294c8b4ade11500b05"
+dependencies = [
+ "nom 6.2.1",
+]
 
 [[package]]
 name = "itertools"
@@ -27,15 +55,27 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+dependencies = [
+ "bitvec",
+ "funty",
+ "memchr",
+ "version_check",
+]
 
 [[package]]
 name = "nom"
@@ -49,7 +89,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "FDSSL"
+name = "fdssl"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,4 +7,5 @@ edition = "2021"
 
 [dependencies]
 nom = "7"
+glsl = "6.0.1"
 itertools = "0.10"

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -2,10 +2,101 @@
     Generator to produce GLSL code from FDSSL
  */
 
-use crate::syntax;
+use std::fmt::format;
 
+use crate::syntax::{self, Expr, ParsedType};
+
+use itertools::Itertools;
 use syntax::Program;
 
-pub fn generate(_prog: Program) -> String {
-    return "blah".to_string();
+use glsl::parser::Parse as _;
+use glsl::syntax::ShaderStage;
+
+pub fn generate(prog: Program) -> String {
+    let mut result = prog.into_iter().map(|expr| generate_expr(&expr));
+    // crudely wrap it, as a general approach
+    let glsl_program = "
+precision highp float;
+precision highp int;
+
+void main() {\n".to_owned() + &result.join("\n") + "\n}\n";
+
+    // TODO, may make more sense to produce a simple IR as part of generation
+    // Would first walk the tree to find information about:
+    // Types that we need to account for in advance (structs, functions, etc)
+    // Special names that are present (color & position for example)
+    // Collect loose exprs into scopes that are not functions (like global/main)
+
+    // first, write up a basic shader that we think an FDSSL program should compile to
+    // compile that with this library, and then get the AST, that's what we can use to map into
+    // let vertShader = "precision highp float;
+    // precision highp int;
+    
+    // attribute vec3 position;
+    // uniform mat4 modelViewMatrix;
+    // uniform mat4 projectionMatrix;
+    // varying vec2 vXY;
+    // uniform float time;
+    
+    // void main() {
+    //   vXY = vec2(position.x, position.y);
+    //   vXY.x = vXY.x * time * 0.1;
+    //   gl_Position = projectionMatrix * modelViewMatrix  * vec4(position, 1.0);
+    // }";
+    // let fragShader = "precision highp float;
+    // precision highp int;
+    
+    // uniform float time;
+    
+    // varying vec2 vXY;
+    
+    // void main() {
+    //   float x = vXY.x + time * 3.3;
+    //   float y = vXY.y + time * 3.7;
+    
+    //   float r = cos(x);
+    //   float g = sin(y);
+    //   float b = r + g;
+    
+    //   gl_FragColor = vec4(r,g,b,1.0);
+    // }";
+
+    // just assume we're only producing a generic shader for now
+
+    // VERIFY this shader
+    let parsed_glsl_program = ShaderStage::parse(glsl_program.clone());
+    assert!(
+        parsed_glsl_program.is_ok(),
+        "Failed to verify resulting GLSL program: {}",
+        parsed_glsl_program.unwrap_err().info
+    );
+    return glsl_program;
+}
+
+fn generate_expr(expr: &Expr) -> String {
+    match expr {
+        Expr::I(i)  => i.to_string(),
+        Expr::B(b)  => b.to_string(),
+        Expr::F(f)  => f.to_string(),
+        Expr::D(d)  => d.to_string(),
+        Expr::Ref(r)    => r.clone(),
+        Expr::Return(be)    => "return ".to_string() + &generate_expr(be).to_string(),
+        Expr::Vect(v)   => "vec".to_owned() + &v.len().to_string() + "(" + &v.into_iter().map(|e| generate_expr(e)).join(",") + ")",
+        Expr::Def { name, typ, value }  => vec![generate_type(typ), name.to_string(), "=".to_string(), generate_expr(value)].join(" ") + ";",
+        Expr::DefMut { name, typ, value }  => vec![generate_type(typ), name.to_string(), "=".to_string(), generate_expr(value)].join(" ") + ";",
+        Expr::UnaryOp { operator, e }   => format!("{}", operator) + &generate_expr(e),
+        Expr::BinOp { operator, e1, e2 } => generate_expr(e1) + &format!("{}", operator) + &generate_expr(e2),
+        Expr::Update { target, value } => target.to_owned() + &" = ".to_string() + &generate_expr(value) + ";",
+        Expr::Comment(v) => v.into_iter().map(|c| "//".to_owned() + &c).join("\n"),
+        e => "// TODO this expr not implemented yet...".to_string(),
+    }
+}
+
+fn generate_type(typ: &ParsedType) -> String {
+    match typ {
+        ParsedType::BaseType(bt)    => bt.to_string(),
+        ParsedType::Tuple(v)    => "vec".to_owned() + &v.len().to_string(), // TODO needs to be reworked for different 'vec' kinds
+        ParsedType::NamedTuple(ne) => "TUPLE_TYPE".to_string(), // TODO needs to be reworked to create a struct
+        ParsedType::Function(t1,t2) => "FUNCTION_TYPE".to_string() // TODO needs to be reworked to create a function? Have to think about this one
+    }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -2,8 +2,6 @@
     Generator to produce GLSL code from FDSSL
  */
 
-use std::fmt::format;
-
 use crate::syntax::{self, Expr, ParsedType};
 
 use itertools::Itertools;
@@ -12,20 +10,54 @@ use syntax::Program;
 use glsl::parser::Parse as _;
 use glsl::syntax::ShaderStage;
 
-pub fn generate(prog: Program) -> String {
-    let mut result = prog.into_iter().map(|expr| generate_expr(&expr));
-    // crudely wrap it, as a general approach
-    let glsl_program = "
-precision highp float;
-precision highp int;
+/**
+ * Structure that captures a generated GLSL program's output.
+ * Split into several sections, allowing us to generate code once from FDSSL,
+ * while still placing generated output into the appropriate locations for GLSL output
+ */
+#[derive(Debug)]
+struct GeneratedProgram {
+    // section for relevant information before checking other details
+    headerSection: Vec<String>,
+    // section for defining types 
+    typeSection: String,
+    // section for defining functions
+    funcSection: String,
+    // sections for main code
+    mainSection: String
+}
 
+pub fn generate(prog: Program) -> String {
+
+    // start with our base generated program
+    let mut generated_program: GeneratedProgram = GeneratedProgram {
+        headerSection: vec![
+            "precision highp float;".to_string(),
+            "precision highp int;".to_string()
+        ],
+        typeSection: "".to_string(),
+        funcSection: "".to_string(),
+        mainSection: "".to_string()
+    };
+
+    // for every expr, pass in our generated program, and retrieve the final result to work with at the end
+    let mut result = prog.into_iter().map(|expr| generate_expr(&mut generated_program, &expr));
+    // crudely wrap it, as a general approach
+    // let glsl_program: String = generated_program.headerSection.join("\n");
+    let glsl_program = "
 void main() {\n".to_owned() + &result.join("\n") + "\n}\n";
+    println!("{:#?}", generated_program);
 
     // TODO, may make more sense to produce a simple IR as part of generation
     // Would first walk the tree to find information about:
     // Types that we need to account for in advance (structs, functions, etc)
     // Special names that are present (color & position for example)
     // Collect loose exprs into scopes that are not functions (like global/main)
+
+    
+
+    // TODO collect loose non-function exprs into a collective group, which will go under 'main'
+    // TODO for lambdas (anonymous functions), those should all be collected into an env, which I can then use to reference to either inline them, or associate a call to them
 
     // first, write up a basic shader that we think an FDSSL program should compile to
     // compile that with this library, and then get the AST, that's what we can use to map into
@@ -64,6 +96,7 @@ void main() {\n".to_owned() + &result.join("\n") + "\n}\n";
     // just assume we're only producing a generic shader for now
 
     // VERIFY this shader
+    println!("{}", glsl_program);
     let parsed_glsl_program = ShaderStage::parse(glsl_program.clone());
     assert!(
         parsed_glsl_program.is_ok(),
@@ -73,30 +106,88 @@ void main() {\n".to_owned() + &result.join("\n") + "\n}\n";
     return glsl_program;
 }
 
-fn generate_expr(expr: &Expr) -> String {
+fn generate_expr(gp: &mut GeneratedProgram, expr: &Expr) -> String {
     match expr {
         Expr::I(i)  => i.to_string(),
         Expr::B(b)  => b.to_string(),
         Expr::F(f)  => f.to_string(),
         Expr::D(d)  => d.to_string(),
         Expr::Ref(r)    => r.clone(),
-        Expr::Return(be)    => "return ".to_string() + &generate_expr(be).to_string(),
-        Expr::Vect(v)   => "vec".to_owned() + &v.len().to_string() + "(" + &v.into_iter().map(|e| generate_expr(e)).join(",") + ")",
-        Expr::Def { name, typ, value }  => vec![generate_type(typ), name.to_string(), "=".to_string(), generate_expr(value)].join(" ") + ";",
-        Expr::DefMut { name, typ, value }  => vec![generate_type(typ), name.to_string(), "=".to_string(), generate_expr(value)].join(" ") + ";",
-        Expr::UnaryOp { operator, e }   => format!("{}", operator) + &generate_expr(e),
-        Expr::BinOp { operator, e1, e2 } => generate_expr(e1) + &format!("{}", operator) + &generate_expr(e2),
-        Expr::Update { target, value } => target.to_owned() + &" = ".to_string() + &generate_expr(value) + ";",
+        Expr::Return(be)    => "return ".to_string() + &generate_expr(gp, be).to_string(),
+        Expr::Vect(v)   => "vec".to_owned() + &v.len().to_string() + "(" + &v.into_iter().map(|e| generate_expr(gp, e)).join(",") + ")",
+        Expr::Def { name, typ, value }  => {
+            // TODO replace 'void' below with the proper 'output' type from 'typ' (which is either a function type, or something that only returns a regular type)
+            return match &**value {
+                Expr::Abs { params: _, body: _ } => {
+                    let return_type = generate_function_return_type(gp, typ);
+                    let out = vec![return_type.to_string(), name.to_string(), generate_expr(gp, value)].join(" ") + ";";
+                    // lift this whole expression up into the global scope, and not locally here
+                    gp.funcSection.push_str(out.clone().as_str());
+                    // don't return anything directly here
+                    return "".to_string();
+                },
+                // fallback to passing the expression along as expected
+                _   => vec![generate_type(gp, typ), name.to_string(), "=".to_string(), generate_expr(gp, value)].join(" ") + ";"
+            };
+        },
+        Expr::DefMut { name, typ, value }  => {
+            let out = vec![generate_type(gp, typ), name.to_string(), "=".to_string(), generate_expr(gp, value)].join(" ") + ";";
+            return match &**value {
+                Expr::Abs { params: _, body: _ } => {
+                    // lift this whole expression up into the global scope, and not locally here
+                    gp.funcSection.push_str(out.clone().as_str());
+                    // don't return anything directly here
+                    return "".to_string();
+                },
+                // fallback to passing the expression along as expected
+                _   => out
+            };
+        },
+        Expr::UnaryOp { operator, e }   => format!("{}", operator) + &generate_expr(gp, e),
+        Expr::BinOp { operator, e1, e2 } => generate_expr(gp, e1) + &format!("{}", operator) + &generate_expr(gp, e2),
+        Expr::Update { target, value } => target.to_owned() + &" = ".to_string() + &generate_expr(gp, value) + ";",
         Expr::Comment(v) => v.into_iter().map(|c| "//".to_owned() + &c).join("\n"),
-        e => "// TODO this expr not implemented yet...".to_string(),
+        Expr::Abs { params, body } => {
+            // treat as a function
+            return "(".to_owned() + &params.into_iter().map(|(n,t)| generate_type(gp,t) + " " + n).join(",") + ") {\n" + &body.into_iter().map(|e| generate_expr(gp,e)).join(";") + "\n}\n";
+        },
+        Expr::App { fname, arguments } => {
+            return fname.to_owned() + "(" + &arguments.into_iter().map(|arg| generate_expr(gp, arg)).join(",") + ");";
+        }
+        e => todo!("Encountered unhandled Expr during Generation: {:?}", e),
     }
 }
 
-fn generate_type(typ: &ParsedType) -> String {
+fn generate_function_return_type(gp: &mut GeneratedProgram, typ: &ParsedType) -> String {
+    return generate_type(gp, typ);
+}
+
+fn generate_type(gp: &mut GeneratedProgram, typ: &ParsedType) -> String {
     match typ {
         ParsedType::BaseType(bt)    => bt.to_string(),
-        ParsedType::Tuple(v)    => "vec".to_owned() + &v.len().to_string(), // TODO needs to be reworked for different 'vec' kinds
-        ParsedType::NamedTuple(ne) => "TUPLE_TYPE".to_string(), // TODO needs to be reworked to create a struct
-        ParsedType::Function(t1,t2) => "FUNCTION_TYPE".to_string() // TODO needs to be reworked to create a function? Have to think about this one
+        ParsedType::Tuple(v)    =>  {
+            // check if all types are the same
+            let isHomogenous = v.into_iter().any(|t| *t != v[0]);
+            if isHomogenous {
+                // express using a vec of the fixed length
+
+                return match v[0] {
+                    ParsedType::BaseType("int") => "ivec".to_owned() + &v.len().to_string(),
+                    ParsedType::BaseType("float") => "vec".to_owned() + &v.len().to_string(),
+                    ParsedType::BaseType("double") => "vec".to_owned() + &v.len().to_string()
+                }
+            } else {
+                // express as a struct type and add the name as a lookup in the future into our GeneratedProgram state
+                // TODO need to add a feature that captures a named lookup (i.e., future references to this type get the name, not the type itself here)
+            }
+        },
+        ParsedType::Function(t1,t2) => {
+            // do nothing, an abstraction will fill in the type as needed
+            return "\n".to_string();
+        },
+        _ => todo!("Unable to generate type: {:?}", typ)
+        // ParsedType::Tuple(v)    =>  //"vec".to_owned() + &v.len().to_string(), // TODO needs to be reworked for different 'vec' kinds
+        // ParsedType::NamedTuple(ne) => "TUPLE_TYPE".to_string(), // TODO needs to be reworked to create a struct
+        // ParsedType::Function(t1,t2) => "FUNCTION_TYPE".to_string() // TODO needs to be reworked to create a function? Have to think about this one
     }
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,0 +1,11 @@
+/*
+    Generator to produce GLSL code from FDSSL
+ */
+
+use crate::syntax;
+
+use syntax::Program;
+
+pub fn generate(_prog: Program) -> String {
+    return "blah".to_string();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ use parser::program;
 use typechecker::tc_program;
 use generator::generate;
 
-
 /// Verify a program through parsing & Typechecking
 fn verify(prog: &str) {
     println!("Verifying program: \n\n{}", prog);
@@ -17,9 +16,6 @@ fn verify(prog: &str) {
             match tc_program(&parsed_prog) {
                 Ok((_, _s)) => {
                     println!("* program typechecked successfully");
-                    println!("* generated GLSL:");
-                    // print generated GLSL
-                    println!("{}", generate(parsed_prog));
                 },
                 Err(e)  => println!("!! Failed to TC program: {:?}", e)
             }
@@ -29,6 +25,11 @@ fn verify(prog: &str) {
 }
 
 fn main() {
+
+    // Easy to test shaders with something like
+    // https://shdr.bkcore.com/
+    // or some other site, there's plenty of these lying around
+
     let prog = "\
     let swap : (int, int) -> (int, int) = (x : int, y : int) { \n\
     \t(y,x)\n\
@@ -57,6 +58,11 @@ fn main() {
     let r2 = program("1+1\n");
     println!("{:?}", r2);
 
+    // program that only sets color
+    let prog2 = "// some comment\nlet color: (float,float,float,float) = (1.0f, 0.5f, 0.5f, 1.0f)\n";
+    let gen = generate_glsl_from_fdssl(prog2.to_string());
+    println!("\nGenerated GLSL:\n{}",gen);
+
     // let x = DefMut {
     //     name: "x".to_string(),
     //     value: Box::new(
@@ -69,4 +75,25 @@ fn main() {
     //         }
     //     ),
     // };
+}
+
+// Helper to parse, typecheck, and generate code from FDSSL
+fn generate_glsl_from_fdssl(prog: String) -> String {
+    let parse_result = program(&prog);
+    assert!(parse_result.is_ok(), "Failed to parse with error: {}", parse_result.unwrap_err());
+    let (_,ast) = parse_result.unwrap();
+
+    let tc_result = tc_program(&ast);
+    assert!(tc_result.is_ok(), "Failed to typecheck with error: {}", tc_result.unwrap_err());
+
+    return generate(ast);
+}
+
+/// General Tests...
+
+#[test]
+fn test_simple_frag_generates() {
+    let prog = "// test comment\nlet color: (float,float,float,float) = (1.0f,0.5f,0.5f,1.0f)\n".to_string();
+    let generated_result = generate_glsl_from_fdssl(prog);
+    println!("Simple Frag program:\n{}", generated_result);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,15 +35,19 @@ fn main() {
     \t(y,x)\n\
     }\n\
     \n\
-    let apply : (int -> int, int) -> int = (f: int -> int, v: int) {\n\
-    \tf(v)\n\
-    }\n\
+    //let apply : (int -> int, int) -> int = (f: int -> int, v: int) {\n\
+    //\tf(v)\n\
+    //}\n\
     \n\
     let double: int -> int = (x: int) {\n\
+        let z1: int = x\n\
+        let z2: int = x\n\
     \tx*2\n\
     }\n\
     \n\
-    apply(double,8)\n\
+   //apply(double,8)\n\
+   double(8)
+   \n\
     ";
     verify(prog);
     
@@ -61,10 +65,10 @@ fn main() {
     // program that only sets color
     let prog2 = "// some comment\nlet color: (float,float,float,float) = (1.0f, 0.5f, 0.5f, 1.0f)\n";
     let gen = generate_glsl_from_fdssl(prog2.to_string());
-    println!("\nGenerated GLSL:\n{}",gen);
+    println!("\n:::: Generated GLSL :::::\n{}",gen);
 
     let gen2 = generate_glsl_from_fdssl(prog.to_string());
-    println!("\nGenerated GLSL 2:\n{}",gen2);
+    println!("\n:::: Generated GLSL 2 :::::\n{}",gen2);
 
     // let x = DefMut {
     //     name: "x".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 mod syntax;
 mod parser;
 mod typechecker;
+mod generator;
 
 use parser::program;
 use typechecker::tc_program;
+use generator::generate;
 
 
 /// Verify a program through parsing & Typechecking
@@ -12,9 +14,12 @@ fn verify(prog: &str) {
     match program(prog) {
         Ok((_, parsed_prog)) => {
             println!("* program parsed successfully");
-            match tc_program(parsed_prog) {
-                Ok((_, s)) => {
+            match tc_program(&parsed_prog) {
+                Ok((_, _s)) => {
                     println!("* program typechecked successfully");
+                    println!("* generated GLSL:");
+                    // print generated GLSL
+                    println!("{}", generate(parsed_prog));
                 },
                 Err(e)  => println!("!! Failed to TC program: {:?}", e)
             }
@@ -46,9 +51,9 @@ fn main() {
         _          => vec![]
     };
     println!("\n\nPARSED PROGRAM: {:?}\n\n", res);
-    println!("TYPECHECKED PROGRAM: {:?}\n\n", tc_program(res));
+    println!("TYPECHECKED PROGRAM: {:?}\n\n", tc_program(&res));
 
-    let r1 = program("(x:1, y:2)");
+    let _r1 = program("(x:1, y:2)");
     let r2 = program("1+1\n");
     println!("{:?}", r2);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,9 @@ fn main() {
     let gen = generate_glsl_from_fdssl(prog2.to_string());
     println!("\nGenerated GLSL:\n{}",gen);
 
+    let gen2 = generate_glsl_from_fdssl(prog.to_string());
+    println!("\nGenerated GLSL 2:\n{}",gen2);
+
     // let x = DefMut {
     //     name: "x".to_string(),
     //     value: Box::new(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -579,6 +579,10 @@ fn test_parse_vect() {
     assert_eq!(parse_expr("(1,true)"), Ok(("", Expr::Vect(vec![Expr::I(1),Expr::B(true)]))), "Failed to parse a mixed vect");
     assert_eq!(parse_expr("(3,)").is_ok(), false, "Recognized an invalid tuple statement");
     assert_eq!(parse_expr("(,3)").is_ok(), false, "Recognized another invalid tuple statement");
+
+    // test assigned vects with & without 'f' modifier to float values
+    assert!(parse_expr("let color: (float,float,float,float) = (1.0, 0.5, 0.5, 1.0)\n").is_ok(), "Failed to parsed assigned tuple");
+    assert!(parse_expr("let color: (float,float,float,float) = (1.0f, 0.5f, 0.5f, 1.0f)\n").is_ok(), "Failed to parsed assigned tuple with 'f's");
 }
 
 /// Tests parsing vectors with names (akin to structs)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -24,7 +24,7 @@ use nom::combinator::{map, verify, recognize, peek, opt, fail, not, eof};
 macro_rules! bop {
     ( $i:expr , $b:expr) => {
         {
-            map(tag($i), |s: &str| $b)
+            map(tag($i), |_s: &str| $b)
         }
     };
 }
@@ -159,7 +159,7 @@ fn parse_return(i: &str) -> IResult<&str, Expr> {
 /// is any type annotation. This allows the type annotation to nest other
 /// structural types. e.g. (t1, (t2, t3), t1 -> t2)
 fn parse_type_tuple(i: &str) -> IResult<&str, ParsedType> {
-    let mut parser =
+    let parser =
         verify(
             delimited(
                 terminated(tag("("), space0),
@@ -305,8 +305,8 @@ fn parse_unary_expr(input: &str) -> IResult<&str, Expr> {
 /// Parses a unary expression
 fn parse_unary_op(input: &str) -> IResult<&str, UOp> {
     preceded(space0, alt((
-        map(tag("-"), |s: &str| UOp::Negative),
-        map(tag("!"), |s: &str| UOp::Negate),
+        map(tag("-"), |_s: &str| UOp::Negative),
+        map(tag("!"), |_s: &str| UOp::Negate),
     )))(input)
 }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -32,22 +32,22 @@ impl fmt::Display for ParsedType {
         match &*self {
             ParsedType::BaseType(s)     => write!(f, "{}", s),
             ParsedType::Tuple(v)        => {
-                write!(f, "(");
+                let _r1 = write!(f, "(");
                 for (i,t) in v.into_iter().enumerate() {
-                    write!(f, "{}", t);
+                    let _r2 = write!(f, "{}", t);
                     if i < (v.len()-1) {
-                        write!(f, ", ");
+                        let _r3 = write!(f, ", ");
                     }
                 }
                 write!(f, ")")
             },
             ParsedType::Function(t1,t2) => write!(f, "{} -> {}", format!("{}",t1), format!("{}",t2)),
             ParsedType::NamedTuple(v)   => {
-                write!(f, "(");
+                let _r1 = write!(f, "(");
                 for (i,t) in v.into_iter().enumerate() {
-                    write!(f, "{}:{}", t.0, *t.1);
+                    let _r2 = write!(f, "{}:{}", t.0, *t.1);
                     if i < (v.len()-1) {
-                        write!(f, ", ");
+                        let _r3 = write!(f, ", ");
                     }
                 }
                 write!(f, ")")

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -168,7 +168,7 @@ pub enum Expr {
         e2: Box<Expr>,
     },
     Update {
-        target: String,
+        target: String, // this is the part where we can update existing bindings, as well as update things like position & color (vert & frag respectively)
         value: Box<Expr>,
     },
     Branch {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -18,12 +18,25 @@ pub enum Type {
 /// This enum is not meant to be used outside the parser and type checker
 /// as it simply denotes the structure of the type rather than any type
 /// space the type occupies.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ParsedType {
     BaseType(String),
     Tuple(Vec<ParsedType>),
     NamedTuple(Vec<(String, Box<ParsedType>)>), // stores indexed types for named tuples
     Function(Box<ParsedType>, Box<ParsedType>),
+}
+
+/**
+ * Returns whether a Tuple type is homogenous
+ */
+pub fn is_homogenous_tuple(pt: &ParsedType) -> bool {
+    match pt {
+        ParsedType::Tuple(v)    => {
+            let first = &v[0];
+            return v.iter().all(|t| *t == *first);
+        },
+        _   => true
+    }
 }
 
 /// User friendly dipslyaing of parsed types in TypeChecker errors

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -744,6 +744,11 @@ fn tc_expr(e: &Expr, mut env: TCEnv) -> TCResult {
             tc_pass(ParsedType::Tuple(tup_type), env)
         },
 
+        Expr::Comment(_) => {
+            // always pass for comments
+            tc_pass(ParsedType::BaseType("NONE".to_string()), env)
+        },
+
 
         // fill in the rest here, and just call out the relevant handler
         _ => tc_fail(format!("Unrecognized expression '{:?}'", e))


### PR DESCRIPTION
This adds in the beginnings of a basic generator that will take an FDSSL AST, and output a concrete GLSL program. It's also possible to directly output a GLSL AST, but currently it's much easier to output literal GLSL than to map to the AST representation. However, using the `glsl` Rust library, we can parse & validate the produced GLSL program, giving us confidence in the result (plus excellent feedback on errors).

There are still many holes in this version, as it's a WIP. Once it's finished up I'll mark it as ready for review.