### PR TITLE
Accumulate Types, Improve TypeChecker, Improve TC(App)

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -128,13 +128,13 @@ pub struct Parameter {
     datatype: Type,
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug,PartialEq,Clone)]
 pub enum AccessType {
     Name(String),
     Idx(Box<Expr>)
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug,PartialEq, Clone)]
 pub enum Expr {
     I(i32),
     B(bool),

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -18,7 +18,7 @@ pub enum Type {
 /// This enum is not meant to be used outside the parser and type checker
 /// as it simply denotes the structure of the type rather than any type
 /// space the type occupies.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum ParsedType {
     BaseType(String),
     Tuple(Vec<ParsedType>),
@@ -26,34 +26,38 @@ pub enum ParsedType {
     Function(Box<ParsedType>, Box<ParsedType>),
 }
 
+impl ParsedType {
+    pub fn arity(&self) -> usize {
+        match self {
+            ParsedType::Tuple(v) => v.len(),
+            ParsedType::NamedTuple(v) => v.len(),
+            _ => 1,
+        }
+    }
+}
+
 /// User friendly dipslyaing of parsed types in TypeChecker errors
 impl fmt::Display for ParsedType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &*self {
-            ParsedType::BaseType(s)     => write!(f, "{}", s),
-            ParsedType::Tuple(v)        => {
-                write!(f, "(");
-                for (i,t) in v.into_iter().enumerate() {
-                    write!(f, "{}", t);
-                    if i < (v.len()-1) {
-                        write!(f, ", ");
-                    }
-                }
-                write!(f, ")")
+        let e_type = match self {
+           ParsedType::BaseType(s)     => s.to_string(),
+           ParsedType::Tuple(v)        => {
+               format!("({})",
+                       v.iter().map(|i| {
+                           format!("{i},")
+                       }).collect::<Vec<String>>().concat()
+               )
             },
-            ParsedType::Function(t1,t2) => write!(f, "{} -> {}", format!("{}",t1), format!("{}",t2)),
+            ParsedType::Function(t1,t2) => format!("{t1} -> {t2}"),
             ParsedType::NamedTuple(v)   => {
-                write!(f, "(");
-                for (i,t) in v.into_iter().enumerate() {
-                    write!(f, "{}:{}", t.0, *t.1);
-                    if i < (v.len()-1) {
-                        write!(f, ", ");
-                    }
-                }
-                write!(f, ")")
-                // write!(f, "({})", format!("{:?}",v))
+               format!("({})",
+                       v.iter().map(|i| {
+                           format!("{}:{},", i.0, *i.1)
+                       }).collect::<Vec<String>>().concat()
+               )
             }
-        }
+        };
+        write!(f, "{e_type}")
     }
 }
 
@@ -99,7 +103,7 @@ impl fmt::Display for BOp {
             BOp::BitOr => "|",
             BOp::BitXor => "^",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -575,7 +575,9 @@ fn tc_expr(e: Expr, mut env: TCEnv) -> TCResult {
             else {
                 // fail, type mismatch!
                 // TODO, improve message
-                tc_fail("Function typecheck failed".to_string())
+                tc_fail(
+                    format!("Function {f} expected parameter type {argType} but received {tcArgs}")
+                )
             }
         }
 
@@ -946,7 +948,7 @@ fn test_tc_app() {
     // Test for function with no parameters
     let onePFuncT : ParsedType = Function(
             Box::new(
-                Tuple(vec![BaseType("int".to_string())])
+                BaseType("int".to_string())
             ),
             Box::new(
                 BaseType("int".to_string())


### PR DESCRIPTION
This is a big ole PR. 

This does 3 things:
- TCEnv is a struct that contains an accumulation of all defined types.
- Fixed clippy warnings and improvements
- Improve the TypeChecker for App expressions (with accompanying test).

Please let me know if I need to break this up.